### PR TITLE
Fix typo error of  extra tilda (`) at the end of JS install ESLint co…

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -38,7 +38,7 @@ node_modules/
 
 1. Run 
     ```
-    npm install --save-dev eslint@7.x eslint-config-airbnb-base@14.x eslint-plugin-import@2.x babel-eslint@10.x`
+    npm install --save-dev eslint@7.x eslint-config-airbnb-base@14.x eslint-plugin-import@2.x babel-eslint@10.x
     ```
     *not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).*
 2. Copy [.eslintrc.json](./.eslintrc.json) to the root directory of your project.


### PR DESCRIPTION
This pull request will fix the error of  #160 **extra tilda (`) at the end** of the command on the README file while installing eslint JavaScript linters.

[Link to installing ESLint](https://github.com/microverseinc/linters-config/tree/master/javascript#:~:text=npm%20install%20--save-dev%20eslint%407.x%20eslint-config-airbnb-base%4014.x%20eslint-plugin-import%402.x%20babel-eslint%4010.x%60)

Instead of
```
npm install --save-dev eslint@7.x eslint-config-airbnb-base@14.x eslint-plugin-import@2.x babel-eslint@10.x
```

It is 
```
npm install --save-dev eslint@7.x eslint-config-airbnb-base@14.x eslint-plugin-import@2.x babel-eslint@10.x`
```